### PR TITLE
Change server name to avoid confusion

### DIFF
--- a/motioneye/rootfs/etc/motioneye/motioneye.conf
+++ b/motioneye/rootfs/etc/motioneye/motioneye.conf
@@ -94,4 +94,4 @@ add_remove_cameras true
 http_basic_auth false
 
 # overrides the hostname (useful if motionEye runs behind a reverse proxy)
-server_name Home Assistant
+server_name motionEye | Hass.io

--- a/motioneye/rootfs/etc/motioneye/motioneye.conf
+++ b/motioneye/rootfs/etc/motioneye/motioneye.conf
@@ -94,4 +94,4 @@ add_remove_cameras true
 http_basic_auth false
 
 # overrides the hostname (useful if motionEye runs behind a reverse proxy)
-server_name motionEye | Hass.io
+server_name CCTV


### PR DESCRIPTION
# Proposed Changes

The current server name can get a bit confusing since it changes the title of the motionEye page.

The only way to know the tab is for motionEye if from the icon:

![tabs](https://user-images.githubusercontent.com/28114703/46695136-a252b700-cc06-11e8-88a7-772ce4cdd356.png)

This changes the server name to `motionEye | Hass.io` so the title is more distinguishable.
