### PR TITLE
Allow add-on to access homeassistant API

### DIFF
--- a/motioneye/config.json
+++ b/motioneye/config.json
@@ -25,7 +25,8 @@
   },
   "boot": "auto",
   "hassio_api": true,
-  "hassio_role": "default",
+  "hassio_role": "homeassistant",
+  "homeassistant_api": true,
   "host_network": true,
   "apparmor": false,
   "privileged": [


### PR DESCRIPTION
# Proposed Changes

This allows using Motion Notification "Run A Command" with `HASSIO_TOKEN` and `http://hassio/homeassistant/api/` address. Allowing toggling a motion sensor when the camera detects motion.

Right now the only way of doing that is using the external URL with a long-lived access token. If you use SSL then is no way of doing it with the local address.

Here's an example with what this will enable us to do:
```bash
curl -X POST -H "Authorization: Bearer ${HASSIO_TOKEN}" -H "Content-Type: application/json" -d '{"payload": "ON", "topic": "home/kitchen/camera/motion", "retain": "True"}' http://hassio/homeassistant/api/services/mqtt/publish
```