### PR TITLE
:fire: Removed redundant copy statement.

### DIFF
--- a/motioneye/rootfs/etc/cont-init.d/motioneye.sh
+++ b/motioneye/rootfs/etc/cont-init.d/motioneye.sh
@@ -12,8 +12,8 @@ if ! bashio::fs.directory_exists '/data/motioneye'; then
 fi
 
 # Needed for existing installations.
-if ! bashio::fs.file_exists "${CONF}"; then
-    cp /etc/motioneye/motion.conf "${CONF}" \
+if ! bashio::fs.file_exists "${MOTION}"; then
+    cp /etc/motioneye/motion.conf "${MOTION}" \
         || bashio::exit.nok 'Failed to create initial motion configuration'
 fi
 

--- a/motioneye/rootfs/etc/cont-init.d/motioneye.sh
+++ b/motioneye/rootfs/etc/cont-init.d/motioneye.sh
@@ -11,12 +11,6 @@ if ! bashio::fs.directory_exists '/data/motioneye'; then
         || bashio::exit.nok 'Failed to create initial motionEye configuration'
 fi
 
-# Needed for existing installations.
-if ! bashio::fs.file_exists "${MOTION}"; then
-    cp /etc/motioneye/motion.conf "${MOTION}" \
-        || bashio::exit.nok 'Failed to create initial motion configuration'
-fi
-
 # Migration
 if bashio::fs.file_exists "${CONF}"; then
     bashio::log.debug "Running startup migrations"


### PR DESCRIPTION
# Proposed Changes

If I'm understanding correctly, the intention of this if-then statement is to create the motion.conf file in /data/motioneye/ if it doesn't exist (i.e. first run of the container)?

If this is the intention, then it should be referencing $MOTION, not $CONF - hence this PR.

That said, I'm not sure if it's necessary at all since the previous if-then copies the entire /etc/motioneye/ directory (inclusive of motion.conf) if /data/motioneye/ does not exist.

My apologies if I've misunderstood.

I love your work!

## Related Issues

N/A
