### PR TITLE
✨ Give add-on access to video devices

### DIFF
--- a/motioneye/config.json
+++ b/motioneye/config.json
@@ -22,6 +22,7 @@
   "hassio_role": "default",
   "host_network": true,
   "apparmor": false,
+  "video": true,
   "privileged": ["DAC_READ_SEARCH", "SYS_ADMIN"],
   "map": ["share:rw", "ssl"],
   "options": {


### PR DESCRIPTION
# Proposed Changes

Should allow to use usb webcams ( /dev/video* ) after recent merge in supervisor: https://github.com/home-assistant/supervisor/pull/1516

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/