### PR TITLE
Updates ffmpeg from 4.2.1-r3 to 4.2.4-r0

### DIFF
--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -20,7 +20,7 @@ RUN \
     \
     && apk add --no-cache \
         cifs-utils=6.9-r1 \
-        ffmpeg=4.2.1-r3 \
+        ffmpeg=4.2.4-r0 \
         libcurl=7.67.0-r0 \
         libjpeg=8-r6 \
         mosquitto-clients=1.6.8-r0 \


### PR DESCRIPTION
# Proposed Changes

Updates version of ffmpeg to 4.2.4-r0 as 4.2.1-r3 is not available anymore inside alpines packages.

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/