### PR TITLE
🚑Build motion locally

### DIFF
--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -41,6 +41,24 @@ RUN \
         python2=2.7.18-r0 \
         v4l-utils=1.20.0-r0 \
     \
+    # Build Motion
+    && MOTION_VERSION=4.3.1 \
+    && curl -J -L -o /tmp/motion.tar.gz \
+        https://github.com/Motion-Project/motion/archive/release-${MOTION_VERSION}.tar.gz \
+    && mkdir -p /tmp/motion \
+    && tar zxf /tmp/motion.tar.gz -C \
+        /tmp/motion --strip-components=1 \
+    && cd /tmp/motion \
+    && autoreconf -fiv \
+	&& ./configure \
+            --without-pgsql \
+            --without-mysql \
+            --without-sqlite3 \
+            --prefix=/usr \
+            --sysconfdir=/etc \
+            --without-optimizecpu \
+    && make install \
+    \
     && python -m ensurepip \
     \
     && pip install --no-cache-dir -r /tmp/requirements.txt \

--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -11,9 +11,18 @@ COPY requirements.txt /tmp/
 # Setup base
 RUN \
     apk add --no-cache --virtual .build-dependencies \
+    	autoconf=2.69-r2 \
+        automake=1.16.2-r0 \
+        build-base=0.5-r2 \
         curl-dev=7.69.1-r1 \
+        ffmpeg-dev=4.3.1-r0 \
         gcc=9.3.0-r2 \
+        gettext-dev=0.20.2-r0 \
+        git=2.26.2-r0 \
         jpeg-dev=9d-r0 \
+        libjpeg-turbo-dev=2.0.5-r0 \
+        libmicrohttpd-dev=0.9.70-r0 \
+        libwebp-dev=1.1.0-r0 \
         musl-dev=1.1.24-r9 \
         python2-dev=2.7.18-r0 \
     \

--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -29,12 +29,17 @@ RUN \
     && apk add --no-cache \
         cifs-utils=6.10-r1 \
         ffmpeg=4.3.1-r0 \
+        ffmpeg-libs=4.3.1-r0 \
         libcurl=7.69.1-r1 \
         libjpeg=9d-r0 \
+        libjpeg-turbo=2.0.5-r0 \
+        libintl=0.20.2-r0 \
+        libmicrohttpd=0.9.70-r0 \
+        libwebp=1.1.0-r0 \
         mosquitto-clients=1.6.9-r0 \
-        motion@edge=4.3.1-r0 \
         nginx=1.18.0-r0 \
         python2=2.7.18-r0 \
+        v4l-utils=1.20.0-r0 \
     \
     && python -m ensurepip \
     \

--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -9,6 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 COPY requirements.txt /tmp/
 
 # Setup base
+# hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \
     	autoconf=2.69-r2 \

--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt /tmp/
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-    	autoconf=2.69-r2 \
+        autoconf=2.69-r2 \
         automake=1.16.2-r0 \
         build-base=0.5-r2 \
         curl-dev=7.69.1-r1 \
@@ -42,7 +42,6 @@ RUN \
         python2=2.7.18-r0 \
         v4l-utils=1.20.0-r0 \
     \
-    # Build Motion
     && MOTION_VERSION=4.3.1 \
     && curl -J -L -o /tmp/motion.tar.gz \
         https://github.com/Motion-Project/motion/archive/release-${MOTION_VERSION}.tar.gz \
@@ -51,7 +50,7 @@ RUN \
         /tmp/motion --strip-components=1 \
     && cd /tmp/motion \
     && autoreconf -fiv \
-	&& ./configure \
+    && ./configure \
             --without-pgsql \
             --without-mysql \
             --without-sqlite3 \


### PR DESCRIPTION
# Proposed Changes

Build motion locally to avoid issues with Alpine Edge and mixing repos (specific to Armv7 32-bit).

## Related Issues

#115 
#116 

Have validated it runs Armv7/32 and X64, assume motion detection is working (although I am not a big Motioneye user, I get the red box which I believe is the frame detection).

Painfully slow on a Pi, so don't understand how people run this anyway 😉 

It will mean another repo to watch for updates if implemented.

Edit - I should add that I am unsure if we need to set the local motion user/group, it appears to work without as I believe motioneye itself will start the process.