### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/motioneye/config.json
+++ b/motioneye/config.json
@@ -4,7 +4,6 @@
   "slug": "motioneye",
   "description": "Simple, elegant and feature-rich CCTV/NVR for your cameras",
   "url": "https://github.com/hassio-addons/addon-motioneye",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:8765]",
   "ingress": true,
   "ingress_port": 0,
   "panel_icon": "mdi:cctv",


### PR DESCRIPTION
# Proposed Changes

Remove `webui` from add-on configuration, as this add-on uses Ingress (thus useless to have in the config)