### PR TITLE
Add basic motionEye integration documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Some cool features of motionEye:
 - Can record continuously, motion, or timelapse, with retention settings.
 - Supports "[action buttons][motioneye-wiki-action-buttons]" within the configuration.
 
+The add-on can optionally be used in conjunction with the [Home Assistant
+motionEye integration](https://www.home-assistant.io/integrations/motioneye/).
+
 [:books: Read the full add-on documentation][docs]
 
 ## Support

--- a/motioneye/DOCS.md
+++ b/motioneye/DOCS.md
@@ -124,6 +124,16 @@ within the motionEye UI.
 
 The bash shell command to be executed when the button is pressed.
 
+## motionEye Integration
+
+This add-on can optionally be used in conjuction with the Home Assistant
+[motionEye integration](https://www.home-assistant.io/integrations/motioneye/)
+to offer motionEye entities natively within Home Assistant.
+
+To configure the integration to use the add-on, simply use
+`http://localhost:28765` as the URL field in the integration configuration,
+along with your admin and surveillance username and password.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]


### PR DESCRIPTION
# Proposed Changes

Minor documentation improvement to make it clear what the URL for the integration should be, when the add-on is used.

## Related Issues

https://github.com/home-assistant/core/issues/50016
https://github.com/home-assistant/core/issues/50409
https://github.com/home-assistant/home-assistant.io/issues/17830
https://github.com/home-assistant/home-assistant.io/issues/17707