### PR TITLE
Add Home Assistant integration discovery

### DIFF
--- a/motioneye/rootfs/etc/services.d/motioneye/discovery
+++ b/motioneye/rootfs/etc/services.d/motioneye/discovery
@@ -1,0 +1,21 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Home Assistant Community Add-on: motionEye
+# Send Discovery information to Home Assistant
+# ==============================================================================
+declare config
+
+# Wait for motionEye to start before continuing
+bashio::net.wait_for 28765
+
+# Create discovery config payload for Home Assistant
+config=$(bashio::var.json \
+    url "http://127.0.0.1:28765"
+)
+
+# Send discovery info
+if bashio::discovery "mmotioneye" "${config}" > /dev/null; then
+    bashio::log.info "Successfully send discovery information to Home Assistant."
+else
+    bashio::log.error "Discovery message to Home Assistant failed!"
+fi

--- a/motioneye/rootfs/etc/services.d/motioneye/discovery
+++ b/motioneye/rootfs/etc/services.d/motioneye/discovery
@@ -14,7 +14,7 @@ config=$(bashio::var.json \
 )
 
 # Send discovery info
-if bashio::discovery "mmotioneye" "${config}" > /dev/null; then
+if bashio::discovery "motioneye" "${config}" > /dev/null; then
     bashio::log.info "Successfully send discovery information to Home Assistant."
 else
     bashio::log.error "Discovery message to Home Assistant failed!"

--- a/motioneye/rootfs/etc/services.d/motioneye/run
+++ b/motioneye/rootfs/etc/services.d/motioneye/run
@@ -15,5 +15,8 @@ if bashio::debug; then
     options+=(-d)
 fi
 
+# Send out discovery information
+./discovery &
+
 # Run the motionEye
 exec meyectl startserver "${options[@]}"


### PR DESCRIPTION
# Proposed Changes

Add support for sending out a discovery signal to Home Assistant, allowing the add-on to trigger the discovery of the motionEye integration.

It will show a discovered integration instance on the integrations dashboard and trigger a persistent message that a new integration has been discovered as well.

- Home Assistant Core PR: <https://github.com/home-assistant/core/pull/50901>
- Supervisor PR: <https://github.com/home-assistant/supervisor/pull/2850>

The supervisor containing the above PR is not yet stable, so this PR will cause an error for users at this point.