### PR TITLE
Enable motionEye discovery in add-on configuration

### DIFF
--- a/motioneye/config.json
+++ b/motioneye/config.json
@@ -16,6 +16,7 @@
   "ports_description": {
     "80/tcp": "Web interface (Not required for Ingress)"
   },
+  "discovery": ["motioneye"],
   "host_network": true,
   "apparmor": false,
   "video": true,


### PR DESCRIPTION
# Proposed Changes

Sets the discovery flag for this add-on in the add-on config.
