### PR TITLE
Typo: no apostrophe in plurals

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Simple, elegant and feature-rich CCTV/NVR for your cameras.
 ## About
 
 motionEye is a popular frontend to the camera software called motion. This
-add-on provides both, allowing you to add your camera's to your Hass.io setup.
+add-on provides both, allowing you to add your cameras to your Hass.io setup.
 
 motionEye is Open Source CCTV and NVR, that is elegant and really easy to use.
 It can be used as a Baby Monitor, Construction Site Montage Viewer,


### PR DESCRIPTION
Typo: No apostrophe in plurals.

# Proposed Changes

Change documentation to correct language.
