### PR TITLE
🔥 Less logging for motionEye add-on log output

### DIFF
--- a/motioneye/rootfs/etc/nginx/nginx.conf
+++ b/motioneye/rootfs/etc/nginx/nginx.conf
@@ -24,11 +24,7 @@ events {
 http {
     include /etc/nginx/includes/mime.types;
 
-    log_format homeassistant '[$time_local] $status '
-                             '$http_x_forwarded_for($remote_addr) '
-                             '$request ($http_user_agent)';
-
-    access_log              /proc/1/fd/1 homeassistant;
+    access_log              off;
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;


### PR DESCRIPTION
# Proposed Changes

Don't push out the access log for NGINX

closes #265