### PR TITLE
:arrow_down: Downgrade pillow to 6.2.2

### DIFF
--- a/motioneye/requirements.txt
+++ b/motioneye/requirements.txt
@@ -3,7 +3,7 @@ futures==3.3.0
 jinja2==2.11.3
 MarkupSafe==1.1.1
 motioneye==0.42.1
-pillow==8.4.0
+pillow==6.2.2
 pycurl==7.43.0.5
 singledispatch==3.7.0
 six==1.16.0


### PR DESCRIPTION
# Proposed Changes

The current version isn't compatible with motionEye.
