### PR TITLE
Fix broken V4L2 support

### DIFF
--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -22,6 +22,7 @@ RUN \
         libjpeg-turbo-dev=2.1.4-r0 \
         libmicrohttpd-dev=0.9.75-r0 \
         libwebp-dev=1.2.4-r1 \
+        linux-headers=5.19.5-r0 \
         musl-dev=1.2.3-r4 \
         python3-dev=3.10.11-r0 \
         v4l-utils-dev=1.22.1-r2 \


### PR DESCRIPTION
# Proposed Changes

This PR fixes V4L2 support, which broke in v0.19.0, caused by removing the `linux-headers` package (too eager cleanup by me).

This PR re-instates it, `motion` now enables it correctly:

![image](https://user-images.githubusercontent.com/195327/233619090-9e8a003a-afb6-491b-a320-f85515314a2e.png)

Major thanks to @hdaf83 for finding this one ❤️ 

fixes #412 
