### PR TITLE
Fix migration scripts

### DIFF
--- a/motioneye/rootfs/etc/s6-overlay/s6-rc.d/init-motioneye/run
+++ b/motioneye/rootfs/etc/s6-overlay/s6-rc.d/init-motioneye/run
@@ -19,13 +19,13 @@ fi
 # Migration
 if bashio::fs.file_exists "${CONF}"; then
     bashio::log.debug "Running startup migrations"
-    /usr/lib/python3.10/site-packages/motioneye/scripts/migrateconf.sh "${CONF}"
+    /usr/lib/python3.11/site-packages/motioneye/scripts/migrateconf.sh "${CONF}"
     find /data/motioneye/ \
         -maxdepth 1 \
         -type f \
         -name "thread-*.conf" \
         -exec \
-            /usr/lib/python3.10/site-packages/motioneye/scripts/migrateconf.sh {} \;
+            /usr/lib/python3.11/site-packages/motioneye/scripts/migrateconf.sh {} \;
 fi
 
 # Configure motion webcontrol access


### PR DESCRIPTION
# Proposed Changes

Fix the motionEye migration scripts. This was missed in the upgrade from Python 3.10 to 3.11 that shipped in Alpine Linux 3.11
