### PR TITLE
Disable disconnecting idle MJPEG clients

### DIFF
--- a/motioneye/rootfs/etc/motioneye/motioneye.conf
+++ b/motioneye/rootfs/etc/motioneye/motioneye.conf
@@ -52,7 +52,7 @@ mjpg_client_timeout 10
 
 # timeout in seconds after which an idle mjpg client is removed
 # (set to 0 to disable)
-mjpg_client_idle_timeout 10
+mjpg_client_idle_timeout 0
 
 # enable SMB shares (requires motionEye to run as root)
 smb_shares true


### PR DESCRIPTION
# Proposed Changes

With this change, the `mjpg_client_idle_timeout ` is set to `0`. This ensures that MPJEG clients are not automatically disconnected. When this is set to the default value of `10`, snapshots cannot be made.

I am using the official motionEye integration, which presumably calls the `picture/1/current/` endpoint. However, as motionEye disconnects clients after 10 seconds, this always results in an empty image when taking a snapshot using the `camera.snaphot` service.

I have been running the latest version of motionEye on a Raspberry Pi for a while (outside of Home Assistant) and have applied the same fix there, as otherwise it's impossible to create snapshots. This has been running fine for at least half a year now. Applying the same fix here as well allows me to use this add-on as well and deprecate my dedicated motionEye instance running on that Raspberry Pi.

Also, when this `mjpg_client_idle_timeout` is not disabled, the camera stream seems to freeze the entire browser (Firefox) randomly sometimes, whereas I don't have this issue with motionEye running on the Raspberry Pi.

**Edit:** It seems like I don't have permissions to add labels and it results in the build failing. I'd like to add the `bugfix` label.