### PR TITLE
[bugfix] Update motioneye to 0.43.1b2.

### DIFF
--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
 ARG MOTION_VERSION="4.6.0"
-ARG MOTIONEYE_VERSION="0.43.1b1"
+ARG MOTIONEYE_VERSION="0.43.1b2"
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \


### PR DESCRIPTION
# Proposed Changes

Updated Motioneye to 0.43.1b2, fixing some small issues, including the one linked below.

## Related Issues

> #476

I've tested the docker build doesn't cause any errors, but I can't figure out how to test this on my hassio instance, so I haven't tested it at runtime.

Changelog in the motioneye repo: https://github.com/motioneye-project/motioneye/releases/tag/0.43.1b2